### PR TITLE
Ganglia frontend

### DIFF
--- a/ganglia-frontend/Dockerfile
+++ b/ganglia-frontend/Dockerfile
@@ -5,7 +5,10 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN sed 's/main$/main universe/' -i /etc/apt/sources.list && \    
     apt-get update -q && \    
     apt-get install -y gmetad ganglia-webfrontend && \
-    ln -s /etc/ganglia-webfrontend/apache.conf /etc/apache2/sites-enabled/001-ganglia.conf
+    a2dissite 000-default && \
+    sed "s/\/ganglia/\//" -i /etc/ganglia-webfrontend/apache.conf && \
+    ln -s /etc/ganglia-webfrontend/apache.conf /etc/apache2/sites-available/000-ganglia.conf && \
+    a2ensite 000-ganglia
 
 # Add the start script
 ADD bin/entry entry

--- a/ganglia-frontend/bin/entry
+++ b/ganglia-frontend/bin/entry
@@ -27,4 +27,4 @@ service apache2 restart
 echo "Using configuration file: $CONFIG_FILE"
 
 # Start gmetad service on foreground
-gmetad -d 1 -p /var/run/gmetad.pid -c $CONFIG_FILE
+gmetad -d 5 -p /var/run/gmetad.pid -c $CONFIG_FILE


### PR DESCRIPTION
Added some minor fixes:

- Ganglia is now the root web application (available on '/'). Default apache site has been disabled.
- Gmetad now is in verbose mode.