### PR TITLE
[elasticsearch-curator] Force version to 2.1.2

### DIFF
--- a/elasticsearch-curator/Dockerfile
+++ b/elasticsearch-curator/Dockerfile
@@ -1,4 +1,4 @@
 FROM ubuntu:14.04
 RUN apt-get update -q && apt-get install -qy python-pip
-RUN pip install elasticsearch-curator
+RUN pip install elasticsearch-curator==2.1.2
 ENTRYPOINT ["/usr/local/bin/curator"]


### PR DESCRIPTION
https://github.com/elastic/curator/blob/master/Changelog.rst#212-22-january-2015
Last release before non-backwards compatible v3.0

https://github.com/elastic/curator/blob/master/Changelog.rst#300-9-march-2015