### PR TITLE
[INF-756] Update consul-template to v0.18.5

### DIFF
--- a/haproxy-consul-template/Dockerfile
+++ b/haproxy-consul-template/Dockerfile
@@ -5,20 +5,20 @@ ENV DEBIAN_FRONTEND noninteractive
 # Install haproxy
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 505D97A41C61B9CD && \
     apt-get update && \
-    apt-get install -y --no-install-recommends haproxy unzip && \
+    apt-get install -y --no-install-recommends haproxy && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
     sed -i "s/ENABLED=0/ENABLED=1/" /etc/default/haproxy
 
 # Install consul-template
-ENV CONSUL_TEMPLATE_MD5 e7aee39b7b2dd9e8b63617bf774e50de
+ENV CONSUL_TEMPLATE_SHA256 f3eea6dcb480ba1f82cd14c6a8f7a739dc844ac067a3541cd186eb4f9920e4e3
 
 RUN deps='curl ca-certificates' && \
     apt-get update && apt-get install -y --no-install-recommends $deps && rm -rf /var/lib/apt/lists/* && \
-    curl -sSL "https://releases.hashicorp.com/consul-template/0.10.0/consul-template_0.10.0_linux_amd64.zip" -o consul-template.zip && \
-    echo "${CONSUL_TEMPLATE_MD5}  consul-template.zip" | md5sum -c && \
-    unzip -d /usr/local/bin consul-template.zip && \
-    rm consul-template.zip && \
+    curl -sSL "https://releases.hashicorp.com/consul-template/0.18.5/consul-template_0.18.5_linux_amd64.tgz" -o consul-template.tar.gz && \
+    echo "${CONSUL_TEMPLATE_SHA256}  consul-template.tar.gz" | sha256sum -c && \
+    tar -xzf consul-template.tar.gz -C /usr/local/bin --touch && \
+    rm consul-template.tar.gz && \
     mkdir -p /etc/consul-template && \
     curl -o /usr/local/bin/filterproxy https://s3.amazonaws.com/scrapinghub-app-splash/filterproxy && \
     chmod 755 /usr/local/bin/filterproxy && \

--- a/haproxy-consul-template/entry
+++ b/haproxy-consul-template/entry
@@ -6,4 +6,4 @@ CONSUL_CONFIG=${1:-/etc/consul-template}
 /usr/local/bin/filterproxy -l :$PORT_8050 -r localhost:$PORT_8051 &
 
 # Start consul-template service
-consul-template -config=$CONSUL_CONFIG
+/usr/local/bin/consul-template -config=$CONSUL_CONFIG


### PR DESCRIPTION
This update is mainly to add some math functions that allows us to calculate `maxconn` based on environment variables and amount of entries in consul.

Consul-template v0.18.5 is the last one supporting legacy configuration options and settings. An upgrade to a further version would need changes in the configuration.

I've already published `scrapinghub/haproxy-consul-template:1.0.2` (based on the `hct_1.0.2` tag) and tested it with `splash/joaquin`.